### PR TITLE
replace double quote with single quote in vuln title

### DIFF
--- a/sonarqube.tpl
+++ b/sonarqube.tpl
@@ -28,7 +28,7 @@
                   {{- end }},
       "type": "VULNERABILITY",
       "primaryLocation": {
-        "message": "{{ .PkgName }} - {{ .VulnerabilityID }} - {{ .Title }}",
+        "message": "{{ .PkgName }} - {{ .VulnerabilityID }} - {{ .Title | replace "\"" "'" }}",
         "filePath": "{{ $result.Target }}"
       }
     }


### PR DESCRIPTION
Vulnerability texts in trivy can contain quotes ("). If a text contains quotes, the generated json report is broken because strings are broken.

This fix just replaces quotes with single quotes